### PR TITLE
Update Readme to include the correct curl example

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ Available on Heroku at <http://gentle-spire-1153.herokuapp.com/tweet>
 
 Using *curl*, you can make calls like so:
 
-`curl -d 'description=Example+of+description' http://localhost:3000/tweet`
+`curl -H 'Content-Type: application/json' -d '{"description":"Example of description"}' http://localhost:3000/tweet`


### PR DESCRIPTION
The current `curl` example always returns "This tweet cannot be tweeted" because the request is being sent with the `curl` default `content-type` which is `application/x-www-form-urlencoded` instead of `json`
